### PR TITLE
Revert react reconciler upgrade

### DIFF
--- a/extensions/checkout-ui/package.json
+++ b/extensions/checkout-ui/package.json
@@ -13,6 +13,6 @@
     },
     "devDependencies": {
         "@types/react": "^18.3.12",
-        "react-reconciler": "^0.31.0"
+        "react-reconciler": "0.29.2"
     }
 }

--- a/extensions/order-status-ui/package.json
+++ b/extensions/order-status-ui/package.json
@@ -12,6 +12,6 @@
     },
     "devDependencies": {
         "@types/react": "^18.3.12",
-        "react-reconciler": "^0.31.0"
+        "react-reconciler": "0.29.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5507,20 +5507,13 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-reconciler@^0.29.0:
+react-reconciler@0.29.2, react-reconciler@^0.29.0:
   version "0.29.2"
   resolved "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz"
   integrity sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
-
-react-reconciler@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.31.0.tgz#6b7390fe8fab59210daf523d7400943973de1458"
-  integrity sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==
-  dependencies:
-    scheduler "^0.25.0"
 
 react-transition-group@^4.4.2:
   version "4.4.5"
@@ -5792,11 +5785,6 @@ scheduler@^0.23.0, scheduler@^0.23.2:
   integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
-
-scheduler@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0.tgz#336cd9768e8cceebf52d3c80e3dcf5de23e7e015"
-  integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
 
 semver-regex@^4.0.5:
   version "4.0.5"


### PR DESCRIPTION
Bring react reconciler back down to 0.29.2 as per https://community.shopify.dev/t/bug-with-react-reconciler/5425