### PR TITLE
Add a capability to safe evaluate custom code

### DIFF
--- a/extensions/order-status-ui/src/OrderStatus.tsx
+++ b/extensions/order-status-ui/src/OrderStatus.tsx
@@ -3,6 +3,7 @@ import {
     useAppliedGiftCards,
     useAppMetafields,
     useBillingAddress,
+    useCartLines,
     useCurrency,
     useCustomer,
     useDiscountAllocations,
@@ -83,6 +84,8 @@ export const OrderStatus = () => {
     const shippingAmount = useSubscription(api?.cost.totalShippingAmount) || undefined;
     const taxAmount = useSubscription(api?.cost.totalTaxAmount) || undefined;
 
+    const cartLines = useCartLines();
+
     const discountCodes = useDiscountCodes();
     const discountAllocations = useDiscountAllocations();
 
@@ -123,6 +126,7 @@ export const OrderStatus = () => {
             >
                 <ReferrerExperience
                     billingAddress={billingAddress}
+                    cartLines={cartLines}
                     country={country}
                     customer={customer}
                     discountAllocations={discountAllocations}

--- a/extensions/order-status-ui/src/ReferrerExperience.tsx
+++ b/extensions/order-status-ui/src/ReferrerExperience.tsx
@@ -27,6 +27,7 @@ import {
     AppliedGiftCard,
     CartDiscountAllocation,
     CartDiscountCode,
+    CartLine,
     Country,
     Customer,
     Money,
@@ -37,6 +38,7 @@ import { I18nTranslate } from "@shopify/ui-extensions/src/surfaces/checkout/api/
 export interface ReferrerEntryPointInputs {
     /* eslint-disable react/no-unused-prop-types */
     readonly billingAddress: MailingAddress;
+    readonly cartLines?: CartLine[];
     readonly country: Country;
     readonly customer: Pick<Customer, "id">;
     readonly discountAllocations: CartDiscountAllocation[];

--- a/extensions/order-status-ui/src/ThankYou.tsx
+++ b/extensions/order-status-ui/src/ThankYou.tsx
@@ -4,6 +4,7 @@ import {
     useAppliedGiftCards,
     useAppMetafields,
     useBillingAddress,
+    useCartLines,
     useCurrency,
     useCustomer,
     useDiscountAllocations,
@@ -79,8 +80,10 @@ export const ThankYou = () => {
 
     const totalAmount = useTotalAmount();
     const subTotalAmount = useSubtotalAmount();
-    const taxAmount = useTotalTaxAmount();
     const shippingAmount = useTotalShippingAmount();
+    const taxAmount = useTotalTaxAmount();
+
+    const cartLines = useCartLines();
 
     const discountCodes = useDiscountCodes();
     const discountAllocations = useDiscountAllocations();
@@ -116,6 +119,7 @@ export const ThankYou = () => {
             >
                 <ReferrerExperience
                     billingAddress={billingAddress}
+                    cartLines={cartLines}
                     country={country}
                     customer={customer}
                     discountAllocations={discountAllocations}

--- a/extensions/order-status-ui/src/context/ReferrerJourneyContext.tsx
+++ b/extensions/order-status-ui/src/context/ReferrerJourneyContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, Dispatch, ReactNode, SetStateAction, useMemo, useState } from "react";
 import { Environment } from "../../../../shared/utils";
 import { MentionMeShopifyConfig } from "../../../../shared/hooks/useMentionMeShopifyConfig";
-import { useSettings } from "@shopify/ui-extensions-react/checkout";
 
 type ImageLocation = "Top" | "Above information notice" | "Above CTA" | "Below CTA";
 
@@ -31,7 +30,8 @@ export const ReferrerJourneyProvider = ({ imageLocation, orderId, mentionMeConfi
     const [errorState, setErrorState] = useState<boolean>(false);
 
     const state = useMemo(() => {
-        const { partnerCode, environment, defaultLocale, localeChoiceMethod, orderTotalTrackingType, customCode } = mentionMeConfig;
+        const { partnerCode, environment, defaultLocale, localeChoiceMethod, orderTotalTrackingType, customCode } =
+            mentionMeConfig;
 
         return {
             imageLocation: imageLocation ?? "Top",

--- a/extensions/order-status-ui/src/context/ReferrerJourneyContext.tsx
+++ b/extensions/order-status-ui/src/context/ReferrerJourneyContext.tsx
@@ -13,6 +13,7 @@ type ReferrerJourneyState = {
     defaultLocale: string;
     localeChoiceMethod: string;
     orderTotalTrackingType: string;
+    customCode?: string;
     errorState: boolean;
     setErrorState: Dispatch<SetStateAction<boolean>>;
 };
@@ -30,7 +31,7 @@ export const ReferrerJourneyProvider = ({ imageLocation, orderId, mentionMeConfi
     const [errorState, setErrorState] = useState<boolean>(false);
 
     const state = useMemo(() => {
-        const { partnerCode, environment, defaultLocale, localeChoiceMethod, orderTotalTrackingType } = mentionMeConfig;
+        const { partnerCode, environment, defaultLocale, localeChoiceMethod, orderTotalTrackingType, customCode } = mentionMeConfig;
 
         return {
             imageLocation: imageLocation ?? "Top",
@@ -40,6 +41,7 @@ export const ReferrerJourneyProvider = ({ imageLocation, orderId, mentionMeConfi
             defaultLocale,
             localeChoiceMethod,
             orderTotalTrackingType,
+            customCode,
             errorState,
             setErrorState,
         };

--- a/extensions/order-status-ui/src/hooks/useReferrerEntryPoint.ts
+++ b/extensions/order-status-ui/src/hooks/useReferrerEntryPoint.ts
@@ -8,10 +8,12 @@ import { consoleError } from "../../../../shared/logging";
 import { ReferrerEntryPointInputs } from "../ReferrerExperience";
 import { logError } from "../../../../shared/sentry";
 import { useQuery } from "@tanstack/react-query";
-import { CartLine } from "@shopify/ui-extensions/build/ts/surfaces/checkout/api/standard/standard";
 
 // Create a safe execution context
-const safeEval = (code: string, segment: string, cartLines?: CartLine[]) => {
+// CartLine is not "any", it's a CartLine type from Shopify, but we use "any" here because they don't allow
+// access to imports across different surfaces in the UI Extensions API. See here for more:
+// https://shopify.dev/docs/api/checkout-ui-extensions/latest/apis/cart-lines
+const safeEval = (code: string, segment: string, cartLines?: any[]) => {
     // Create a function with limited scope
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     const fn = new Function(

--- a/extensions/order-status-ui/src/hooks/useReferrerEntryPoint.ts
+++ b/extensions/order-status-ui/src/hooks/useReferrerEntryPoint.ts
@@ -37,7 +37,11 @@ const safeEval = (code: string, segment: string, cartLines?: any[]) => {
         if (r && typeof r === "object") {
             return r;
         }
-    } catch (e) {}
+
+        consoleError("safeEval", "Custom code did not return an object. It returned " + typeof r, r);
+    } catch (e) {
+        consoleError("safeEval", "Custom code execution failed", e);
+    }
 
     return {};
 };

--- a/shared/hooks/useMentionMeShopifyConfig.ts
+++ b/shared/hooks/useMentionMeShopifyConfig.ts
@@ -18,6 +18,7 @@ export interface MentionMeShopifyConfig {
     localeChoiceMethod?: string;
     orderTotalTrackingType?: string;
     refereeBannerImage?: Image;
+    customCode?: string;
 }
 
 interface Props {


### PR DESCRIPTION
Exploit that Shopify allows us to execute eval so we can allow clients to run custom code on cartLines.